### PR TITLE
Update adservice image to obusorezekiel/adservice:

### DIFF
--- a/manifests/adservice.yml
+++ b/manifests/adservice.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: obusorezekiel/adservice:latest
+        image: obusorezekiel/adservice:
         ports:
         - containerPort: 9555
         env:


### PR DESCRIPTION
This PR updates the adservice image tag to `obusorezekiel/adservice:`.
Please review and merge to deploy the updated image.