### PR TITLE
Update adservice image to obusorezekiel/adservice:11-cca600c

### DIFF
--- a/manifests/adservice.yml
+++ b/manifests/adservice.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: obusorezekiel/adservice:
+        image: obusorezekiel/adservice:11-cca600c
         ports:
         - containerPort: 9555
         env:


### PR DESCRIPTION
This pull request updates the adservice image tag to `obusorezekiel/adservice:11-cca600c`.
Please review and merge to deploy the updated image to the cluster.