### PR TITLE
Update cartservice image to obusorezekiel/cartservice:8-88c0aa5

### DIFF
--- a/manifests/cartservice.yml
+++ b/manifests/cartservice.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: obusorezekiel/cartservice:latest
+        image: obusorezekiel/cartservice:8-88c0aa5
         ports:
         - containerPort: 7070
         env:
@@ -64,7 +64,7 @@ spec:
     spec:
       containers:
       - name: redis
-        image: redis:alpine
+        image: obusorezekiel/cartservice:8-88c0aa5
         ports:
         - containerPort: 6379
         readinessProbe:


### PR DESCRIPTION
This pull request updates the cartservice image tag to `obusorezekiel/cartservice:8-88c0aa5`.
Please review and merge to deploy the updated image to the cluster.