### PR TITLE
Update checkoutservice image to obusorezekiel/checkoutservice:4-ffdb739

### DIFF
--- a/manifests/checkoutservice.yml
+++ b/manifests/checkoutservice.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: obusorezekiel/checkoutservice:latest
+          image: obusorezekiel/checkoutservice:4-ffdb739
           ports:
           - containerPort: 5050
           readinessProbe:


### PR DESCRIPTION
This pull request updates the checkoutservice image tag to `obusorezekiel/checkoutservice:4-ffdb739`.
Please review and merge to deploy the updated image to the cluster.